### PR TITLE
Fix overlay

### DIFF
--- a/bubbleclicker/index.html
+++ b/bubbleclicker/index.html
@@ -20,14 +20,10 @@
 
 
 
-      <div class="layer-hidden gameover large-12" id="gameOver">
-
-       <div class="spacer">
-           <div id="gameover">time out, your score:</div>
+      <div class="layer-hidden large-12" id="gameover">
+           <h1>time out, your score:</h1>
            <div id="total">0</div>
            <a href="javascript:history.go(0)">Restart</a>
-       </div>
-
    </div>
 
 

--- a/bubbleclicker/main.js
+++ b/bubbleclicker/main.js
@@ -12,8 +12,9 @@ let bubbleSixImg = document.getElementById("bubbleSixImg");
 let counter = document.getElementById("counter");
 let debug = document.getElementById("debug");
 let showOverlay = document.getElementById("showOverlay");
-let gameoOver = document.getElementById("gameOver");
+let gameover = document.getElementById("gameover");
 let close = document.getElementById("close");
+let total = document.getElementById("total");
 
 /* startet das update alle sekunde */
 var interval = setInterval(function() {
@@ -84,9 +85,8 @@ function createProgressbar(id, duration, callback) {
 
 addEventListener('load', function() {
   createProgressbar('progressbar1', '40s', function() {
-  //  alert('Time out. Your Score is ');
-
-
+    gameover.classList.remove("layer-hidden");
+    total.innerHTML = points;
 });
 });
 //-----------------------------

--- a/bubbleclicker/style.css
+++ b/bubbleclicker/style.css
@@ -9,7 +9,7 @@ body {
     display: none;
 }
 
-.gameover{
+#gameover{
     position: fixed;
     top: 0;
     left: 0;
@@ -19,6 +19,7 @@ body {
     text-align: center;
     color: #ffffff;
     font-size: 2rem ;
+    z-index: 900;
 }
 
 .viewport {


### PR DESCRIPTION
Die Variable `total` hinzugefügt und mit dem html Element `#total` im gameoverscreen `#gameover` verknüpft:
```JS
let total = document.getElementById("total");
```
1. Danach mit der Zeile `total.innerHTML = points;` die Punkte innerhalb dem #total div ausgeben:
2. `gameover.classList.remove("layer-hidden");` entfernt die Klasse und macht das div `#gameover` sichtbar:
```JS
addEventListener('load', function() {
  createProgressbar('progressbar1', '40s', function() {
  gameover.classList.remove("layer-hidden");
  total.innerHTML = points;
});
});
```

Hier habe ich unnötige divs und Verschachtelungen gelöscht, sowie eine definitive ID `#gameover` festgelegt, damit steuerst du den gameoverscreen an:
```HTML
<div class="layer-hidden large-12" id="gameover">
   <h1>time out, your score:</h1>
   <div id="total">0</div>
   <a href="javascript:history.go(0)">Restart</a>
</div>
```

Die JS Variable noch an den veränderten HTML div angepasst:
```JS
let gameover = document.getElementById("gameover");
```

Die Definition `z-index: 900;`hinzugefügt. Das kannst du dir wie eine Ebenenreihenfolge vorstellen, höhere Zahlen sind auch in der Ebenenhierarchie höher
```CSS
#gameover{
    position: fixed;
    top: 0;
    left: 0;
    right: 0;
    bottom: 0;
    background-color: #FF0000;
    text-align: center;
    color: #ffffff;
    font-size: 2rem ;
    z-index: 900;
}
```